### PR TITLE
Resolve SyntaxWarning errors

### DIFF
--- a/interaction_engine/interfaces/terminal_client_and_server_interface.py
+++ b/interaction_engine/interfaces/terminal_client_and_server_interface.py
@@ -66,7 +66,7 @@ def input_multiple_choice(message):
 
 def direct_input(_):
     response = ''
-    while len(response) is 0:
+    while len(response) == 0:
         response = input(">>> ")
 
     return response

--- a/interaction_engine/messager/directed_graph.py
+++ b/interaction_engine/messager/directed_graph.py
@@ -41,7 +41,7 @@ class DirectedGraph(BaseMessenger):
         is_exit_node = False
         for node in nodes:
             for transition_node in node.transitions:
-                if transition_node is exit_code:
+                if transition_node == exit_code:
                     is_exit_node = True
                 elif transition_node not in list(self._nodes_dict.keys()):
                     raise ValueError(f"Not all transitions are valid: '{transition_node}'")
@@ -85,7 +85,7 @@ class DirectedGraph(BaseMessenger):
         if not self.is_active:
             raise RuntimeError("Currently inactive")
         new_node = self._nodes_dict[self.current_node].get_transition(user_input)
-        if new_node is self._exit_code:
+        if new_node == self._exit_code:
             self._is_active = False
         else:
             self._current_node_name = new_node

--- a/interaction_engine/messager/message.py
+++ b/interaction_engine/messager/message.py
@@ -100,7 +100,7 @@ class Message(BaseMessenger):
 
         text = lists.make_sure_is_iterable(text)
         result = [self._text_populator.run(t) for t in text]
-        if len(result) is 1:
+        if len(result) == 1:
             return result[0]
         else:
             return result

--- a/interaction_engine/messager/node.py
+++ b/interaction_engine/messager/node.py
@@ -69,7 +69,7 @@ class Node:
         return self._message
 
     def get_transition(self, user_input):
-        if len(self._transitions) is 1:
+        if len(self._transitions) == 1:
             return self._transitions[0]
         elif self._transition_fn is None:
             return self._transitions[

--- a/interaction_engine/text_populator/base_populator.py
+++ b/interaction_engine/text_populator/base_populator.py
@@ -38,4 +38,4 @@ class BasePopulator(ABC):
             else:
                 return False
 
-        return num_in_main is 1
+        return num_in_main == 1


### PR DESCRIPTION
Replace `is` with `==`. I found that using `is` instead of `==` led to issues with exit transitions. 