### PR TITLE
Minor changes for convenience

### DIFF
--- a/interaction_engine/interfaces/client_and_server_interface.py
+++ b/interaction_engine/interfaces/client_and_server_interface.py
@@ -31,11 +31,6 @@ class ClientAndServerInterface(Interface):
             is_create_db_key_if_not_exist=is_create_db_key_if_not_exist
         )
 
-        if (
-                database is not None
-                and not type(database) == Database
-        ):
-            raise TypeError
         self._db = database
         self._is_create_db_key_if_not_exist = is_create_db_key_if_not_exist
 

--- a/interaction_engine/interfaces/interface.py
+++ b/interaction_engine/interfaces/interface.py
@@ -17,11 +17,6 @@ class Interface:
             output_fn = lambda _: _
         self._output_fn = output_fn
 
-        if (
-                database is not None
-                and not type(database) is Database
-        ):
-            raise TypeError
         self._db = database
         self._is_create_db_key_if_not_exist = is_create_db_key_if_not_exist
 

--- a/interaction_engine/messager/message.py
+++ b/interaction_engine/messager/message.py
@@ -16,6 +16,7 @@ class Message(BaseMessenger):
             content,
             options,
             message_type,
+            name=None,
             args=None,
             result_convert_from_str_fn=str,
             result_db_key=None,
@@ -35,7 +36,14 @@ class Message(BaseMessenger):
         except Exception as e:
             raise e
         self._content = content
-        super().__init__(self._content)
+
+        if name is None:
+            self._name = self._content
+        else:
+            if type(name) is not str:
+                raise TypeError("Message name must be a string")
+            self._name = name
+        super().__init__(self._name)
 
         self._options = None
         self.options = options

--- a/interaction_engine/messager/node.py
+++ b/interaction_engine/messager/node.py
@@ -30,6 +30,7 @@ class Node:
                 content=content,
                 options=options,
                 message_type=message_type,
+                name=name,
                 args=args,
                 result_convert_from_str_fn=result_convert_from_str_fn,
                 result_db_key=result_db_key,


### PR DESCRIPTION
I removed the database type checking from the interfaces in order to use the mongodb_statedb without having to list it as a project requirement here. I also added a name option to messages and nodes for convenience. Message names used to be the content of the message, which could be long and confusing especially with SSML tags added.