### PR TITLE
Handle user input errors in engine

### DIFF
--- a/interaction_engine/engine.py
+++ b/interaction_engine/engine.py
@@ -28,8 +28,11 @@ class InteractionEngine:
         for m in messagers:
             self._messagers[m.name] = m
 
+        self._is_running = False
+
     def run(self):
-        while self._plan.is_active:
+        self._is_running = True
+        while self._plan.is_active and self._is_running:
             self.run_next_plan()
 
     def run_next_plan(self):
@@ -40,8 +43,11 @@ class InteractionEngine:
         messager.reset()
 
         pre_hook()
-        while messager.is_active:
+        while messager.is_active and self._is_running:
             msg = messager.get_message()
             user_response = self._interface.run(msg)
-            messager.transition(user_response)
+            try:
+                messager.transition(user_response)
+            except ValueError:
+                self._is_running = False
         post_hook()


### PR DESCRIPTION
I've added an additional `if` condition that stops the engine if the user input returned by the interface is invalid. This is useful because the Cordial interface returns an empty string if there is a timeout, and there is currently no way to handle that. 